### PR TITLE
Clarify UI by adding color dots to edit

### DIFF
--- a/Bayes Believer/Views/UpdateBeliefView.swift
+++ b/Bayes Believer/Views/UpdateBeliefView.swift
@@ -63,13 +63,21 @@ struct BeliefUpdateView: View {
         .multilineTextAlignment(.center)
       Divider()
       if (observation) {
-        Text("Suppose this is true, how likely is it to observe the evidence?")
-          .multilineTextAlignment(.leading)
-          .padding(0.0)
+        HStack {
+          Image(systemName: "circle.fill")
+            .foregroundColor(Color(UIColor.systemBlue))
+          Text("Suppose this is true, how likely is it to observe the evidence?")
+            .multilineTextAlignment(.leading)
+            .padding(0.0)
+        }
       } else {
-        Text("Suppose this is false, how likely is it to observe the evidence?")
-          .multilineTextAlignment(.leading)
-          .padding(0.0)
+        HStack {
+          Image(systemName: "circle.fill")
+            .foregroundColor(Color(UIColor.systemRed))
+          Text("Suppose this is false, how likely is it to observe the evidence?")
+            .multilineTextAlignment(.leading)
+            .padding(0.0)
+          }
       }
       HStack {
         TextField("", value: binding, formatter: formatter)


### PR DESCRIPTION
Clarify UI by adding color dots to edit:
<img width="320" alt="Screen Shot 2022-07-28 at 20 27 11" src="https://user-images.githubusercontent.com/18382390/181611254-b4f993cd-41e3-4287-b87f-7dc834de23e3.png">
